### PR TITLE
Release 0.0.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,10 @@ script: 'bundle exec rake spec'
 rvm:
   - 1.9.3
   - 2.0.0
+  - 2.1
   - jruby-19mode
   - jruby-head
-  - rbx-19mode
+  - rbx
 matrix:
   allow_failures:
     - rvm: ruby-head

--- a/Gemfile.devtools
+++ b/Gemfile.devtools
@@ -1,50 +1,51 @@
 # encoding: utf-8
 
 group :development do
-  gem 'rake',       '~> 10.1.0'
-  gem 'rspec',      '~> 2.14.1'
-  gem 'rspec-core', '~> 2.14.8'
-  gem 'yard',       '~> 0.8.7'
+  gem 'rake',       '~> 10.3.2'
+  gem 'rspec',      '~> 3.1.0'
+  gem 'rspec-its',  '~> 1.0.1'
+  gem 'yard',       '~> 0.8.7.4'
 
   platform :rbx do
     gem 'rubysl-singleton', '~> 2.0.0'
+    gem 'rubinius-coverage', '~> 2.0.1'
   end
 end
 
 group :yard do
-  gem 'kramdown', '~> 1.3.2'
+  gem 'kramdown', '~> 1.3.3'
 end
 
 group :guard do
-  gem 'guard',         '~> 2.4.0'
+  gem 'guard',         '~> 2.6.1'
   gem 'guard-bundler', '~> 2.0.0'
-  gem 'guard-rspec',   '~> 4.2.6'
-  gem 'guard-rubocop', '~> 1.0.2'
+  gem 'guard-rspec',   '~> 4.2.9'
+  gem 'guard-rubocop', '~> 1.1.0'
 
   # file system change event handling
-  gem 'listen',     '~> 2.5.0'
+  gem 'listen',     '~> 2.7.7'
   gem 'rb-fchange', '~> 0.0.6', require: false
-  gem 'rb-fsevent', '~> 0.9.3', require: false
-  gem 'rb-inotify', '~> 0.9.0', require: false
+  gem 'rb-fsevent', '~> 0.9.4', require: false
+  gem 'rb-inotify', '~> 0.9.5', require: false
 
   # notification handling
-  gem 'libnotify',               '~> 0.8.0', require: false
+  gem 'libnotify',               '~> 0.8.3', require: false
   gem 'rb-notifu',               '~> 0.0.4', require: false
   gem 'terminal-notifier-guard', '~> 1.5.3', require: false
 end
 
 group :metrics do
   gem 'coveralls', '~> 0.7.0'
-  gem 'flay',      '~> 2.4.0'
-  gem 'flog',      '~> 4.2.0'
-  gem 'reek',      '~> 1.3.2'
-  gem 'rubocop',   '~> 0.18.1'
-  gem 'simplecov', '~> 0.8.2'
+  gem 'flay',      '~> 2.5.0'
+  gem 'flog',      '~> 4.2.1'
+  gem 'reek',      '~> 1.3.7'
+  gem 'rubocop',   '~> 0.23.0'
+  gem 'simplecov', '~> 0.7.1'
   gem 'yardstick', '~> 0.9.9'
 
   platforms :mri do
-    gem 'mutant',       '~> 0.5.7'
-    gem 'mutant-rspec', '~> 0.5.3'
+    gem 'mutant',       '~> 0.6.3'
+    gem 'mutant-rspec', '~> 0.6.3'
   end
 
   platforms :ruby_19, :ruby_20 do
@@ -53,10 +54,10 @@ group :metrics do
 
   platform :rbx do
     gem 'json',               '~> 1.8.1'
-    gem 'racc',               '~> 1.4'
+    gem 'racc',               '~> 1.4.11'
     gem 'rubysl-logger',      '~> 2.0.0'
     gem 'rubysl-open-uri',    '~> 2.0.0'
-    gem 'rubysl-prettyprint', '~> 2.0.2'
+    gem 'rubysl-prettyprint', '~> 2.0.3'
   end
 end
 
@@ -66,6 +67,6 @@ end
 
 platform :jruby do
   group :jruby do
-    gem 'jruby-openssl', '~> 0.8.5'
+    gem 'jruby-openssl', '~> 0.9.4'
   end
 end

--- a/vanguard.gemspec
+++ b/vanguard.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name        = 'vanguard'
-  s.version     = '0.0.4'
+  s.version     = '0.0.5'
   s.authors     = ['Markus Schirp']
   s.email       = ['mbj@schirp-dso.com']
   s.homepage    = 'https://github.com/mbj/vanguard'


### PR DESCRIPTION
- updates devtools
- bumps version
- dependencies were already bumped in a33784093ae60501c02dfb322e960dd64a746cbb

I needed to update devtools, because there is no lockfile in the gem repo. So with every new clone it fetches latest devtools.
